### PR TITLE
feat(categories): Press and Journalism - categoryId field

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,11 +11,27 @@
 ```js
 {
   press {
-    _id,
-    author,
-    title,
-    excerpt,
+    _id
+    author
+    title
+    excerpt
     releaseDate
+    categoryId
+  }
+}
+```
+
+#### Get all Press by category ID
+
+```js
+{
+  pressCategory(categoryId: 1) {
+    _id
+    author
+    title
+    excerpt
+    releaseDate
+    categoryId
   }
 }
 ```
@@ -288,6 +304,9 @@ mutation($id: ID!) {
 ## **Journalism**
 
 - GET `api/journalism`
+  - returns 200 with an array of objects
+
+- GET `api/journalism/category/2`
   - returns 200 with an array of objects
 
 - POST `api/journalism`

--- a/config/graphql/resolvers/queries/press.js
+++ b/config/graphql/resolvers/queries/press.js
@@ -10,6 +10,7 @@ const PressQueryResolvers = {
 
 
     const mapped = pressReducer(sortedArticles);
+
     return mapped;
   },
   async pressArticle(root, {

--- a/config/graphql/resolvers/queries/press.js
+++ b/config/graphql/resolvers/queries/press.js
@@ -13,6 +13,18 @@ const PressQueryResolvers = {
 
     return mapped;
   },
+  async pressCategory(root, {
+    categoryId
+  }) {
+    const articles = await Press.findByCategoryId(categoryId);
+
+    const sortedArticles = articles.sort((a, b) =>
+      new Date(a.releaseDate) - new Date(b.releaseDate)).reverse();
+
+    const mapped = pressReducer(sortedArticles);
+
+    return mapped;
+  },
   async pressArticle(root, {
     _id
   }) {

--- a/config/graphql/schema.js
+++ b/config/graphql/schema.js
@@ -66,7 +66,7 @@ const schema = gql`
   type Press {
     _id: ID!
     author: String!
-    category: String
+    categoryId: Int
     title: String!
     excerpt: String!
     externalLink: String!
@@ -76,7 +76,7 @@ const schema = gql`
 
   input PressInput {
     author: String!
-    category: String!
+    categoryId: String!
     title: String!
     excerpt: String!
     externalLink: String!
@@ -106,7 +106,7 @@ const schema = gql`
     externalLink: String
     image: ImageObject
     releaseDate: String
-    category: String!
+    categoryId: Int!
   }
 
   type Gig {

--- a/config/graphql/schema.js
+++ b/config/graphql/schema.js
@@ -152,6 +152,7 @@ const schema = gql`
     newsArticleByUrlTitle(urlTitle: String!): NewsArticle
 
     press: [Press],
+    pressCategory(categoryId: ID!): [Press],
     pressArticle(_id: ID!): Press,
 
     cloudinarySignature: CloudinarySignature

--- a/config/graphql/schema.js
+++ b/config/graphql/schema.js
@@ -7,8 +7,8 @@ const schema = gql`
   }
 
   input ImageObjectInput {
-    cloudinaryUrl: String!
-    cloudinaryPublicId: String!
+    cloudinaryUrl: String
+    cloudinaryPublicId: String
   }
 
   type NewsImageObject {

--- a/config/graphql/schema.js
+++ b/config/graphql/schema.js
@@ -2,8 +2,8 @@ const { gql } = require('apollo-server-express');
 
 const schema = gql`
   type ImageObject {
-    cloudinaryUrl: String!
-    cloudinaryPublicId: String!
+    cloudinaryUrl: String
+    cloudinaryPublicId: String
   }
 
   input ImageObjectInput {
@@ -66,6 +66,7 @@ const schema = gql`
   type Press {
     _id: ID!
     author: String!
+    category: String
     title: String!
     excerpt: String!
     externalLink: String!
@@ -75,6 +76,7 @@ const schema = gql`
 
   input PressInput {
     author: String!
+    category: String!
     title: String!
     excerpt: String!
     externalLink: String!
@@ -104,6 +106,7 @@ const schema = gql`
     externalLink: String
     image: ImageObject
     releaseDate: String
+    category: String!
   }
 
   type Gig {

--- a/server/controllers/journalism.controller.js
+++ b/server/controllers/journalism.controller.js
@@ -14,7 +14,7 @@ function createSingle(req, res, next) {
     image: req.body.image,
     releaseDate: req.body.releaseDate,
     externalLink: req.body.externalLink,
-    category: req.body.category,
+    categoryId: Number(req.body.categoryId),
     createdAt: new Date()
   });
   verifyToken(req, res, next)

--- a/server/controllers/journalism.controller.js
+++ b/server/controllers/journalism.controller.js
@@ -11,10 +11,10 @@ function createSingle(req, res, next) {
   const journalismObj = new Journalism({
     title: req.body.title,
     copy: req.body.copy,
-    // imageUrl: req.body.imageUrl,
     image: req.body.image,
     releaseDate: req.body.releaseDate,
     externalLink: req.body.externalLink,
+    category: req.body.category,
     createdAt: new Date()
   });
   verifyToken(req, res, next)

--- a/server/controllers/journalism.controller.js
+++ b/server/controllers/journalism.controller.js
@@ -7,6 +7,12 @@ function getAll(req, res, next) {
     .catch(err => next(err));
 }
 
+function getAllByCategoryId(req, res, next) {
+  Journalism.find({ categoryId: req.params.categoryId })
+    .then(journalism => res.json(journalism))
+    .catch(err => next(err));
+}
+
 function createSingle(req, res, next) {
   const journalismObj = new Journalism({
     title: req.body.title,
@@ -60,6 +66,7 @@ function removeSingle(req, res) {
 
 module.exports = {
   getAll,
+  getAllByCategoryId,
   createSingle,
   loadSingle,
   getSingle,

--- a/server/models/journalism.model.js
+++ b/server/models/journalism.model.js
@@ -32,6 +32,10 @@ const Journalism = new mongoose.Schema({
     type: String,
     required: true
   },
+  category: {
+    type: String,
+    required: true
+  },
   createdAt: {
     type: String,
     required: true

--- a/server/models/journalism.model.js
+++ b/server/models/journalism.model.js
@@ -32,8 +32,8 @@ const Journalism = new mongoose.Schema({
     type: String,
     required: true
   },
-  category: {
-    type: String,
+  categoryId: {
+    type: Number,
     required: true
   },
   createdAt: {

--- a/server/models/press.model.js
+++ b/server/models/press.model.js
@@ -54,6 +54,18 @@ PressSchema.statics = {
       });
   },
 
+  findByCategoryId(categoryId) {
+    return this.find({ categoryId })
+      .exec()
+      .then((press) => {
+        if (press) {
+          return press;
+        }
+        const err = new APIError('No such press exists', httpStatus.NOT_FOUND);
+        return Promise.reject(err);
+      });
+  },
+
   getSingle(id) {
     return this.findById(id)
       .exec()

--- a/server/models/press.model.js
+++ b/server/models/press.model.js
@@ -12,7 +12,7 @@ const PressSchema = new mongoose.Schema({
   },
   categoryId: {
     type: Number,
-    // required: true
+    required: true
   },
   title: {
     type: String,

--- a/server/models/press.model.js
+++ b/server/models/press.model.js
@@ -10,8 +10,8 @@ const PressSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  category: {
-    type: String
+  categoryId: {
+    type: Number,
     // required: true
   },
   title: {

--- a/server/models/press.model.js
+++ b/server/models/press.model.js
@@ -10,6 +10,10 @@ const PressSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  category: {
+    type: String
+    // required: true
+  },
   title: {
     type: String,
     required: true

--- a/server/routes/journalism.route.js
+++ b/server/routes/journalism.route.js
@@ -5,13 +5,17 @@ const journalismCtrl = require('../controllers/journalism.controller');
 const router = express.Router(); // eslint-disable-line new-cap
 
 router.route('/')
-  /** GET /api/journalism - Get all */
+  /** GET /api/journalism - Get all journalism articles */
   .get(journalismCtrl.getAll)
 
   /** POST /api/journalism - Create journalism */
   .post(passport.authenticate('jwt', { session: false }), (req, res, next) => {
     journalismCtrl.createSingle(req, res, next);
   });
+
+router.route('/category/:categoryId')
+  /** GET /api/journalism/category/:categoryId - Get journalism articles by category ID */
+  .get(journalismCtrl.getAllByCategoryId);
 
 router.route('/:journalismId')
   /** GET /api/journalism/:id - Get journalism */


### PR DESCRIPTION
This PR adds a `categoryId` field to press and journalism.

## Changes

- Add `categoryId` to press and journalism DB models.
- Add a new GQL resolver, `pressCategory`, to get all articles in a press category by ID.
- Add a new GET endpoint, `/category/:categoryId`, to get all articles in a journalism category by ID.